### PR TITLE
Upgrade to PHP 8.1+ and Laravel 10/11/12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,14 +3,24 @@
     "description": "This is the latest simplified way to embed Mpesa payments in your laravel application.",
     "type": "library",
     "require": {
-        "php": ">=7.0",
-        "illuminate/support": ">=5.8",
+        "php": "^8.1|^8.2|^8.3|^8.4",
+        "illuminate/support": "^10.0|^11.0|^12.0",
+        "illuminate/console": "^10.0|^11.0|^12.0",
         "nakatsinho/mpesa-php": "dev-master"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^10.0|^11.0|^12.0",
+        "orchestra/testbench": "^8.0|^9.0|^10.0"
     },
     "license": "MIT",
     "autoload": {
         "psr-4": {
             "Nakatsinho\\MpesaLaravel\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests/"
         }
     },
     "extra": {
@@ -29,5 +39,6 @@
             "email": "nakatsinho@gmail.com"
         }
     ],
-    "minimum-stability": "dev"
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true"
 >
@@ -12,20 +12,17 @@
             <directory suffix="Test.php">./tests/Feature</directory>
         </testsuite>
     </testsuites>
-    <coverage processUncoveredFiles="true">
+    <source>
         <include>
-            <directory suffix=".php">./app</directory>
+            <directory suffix=".php">./src</directory>
         </include>
-    </coverage>
+    </source>
     <php>
         <env name="APP_ENV" value="testing"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_DRIVER" value="array"/>
-        <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <env name="DB_DATABASE" value=":memory:"/> -->
         <env name="MAIL_MAILER" value="array"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>
-        <env name="TELESCOPE_ENABLED" value="false"/>
     </php>
 </phpunit>

--- a/src/Commands/PublishSDK.php
+++ b/src/Commands/PublishSDK.php
@@ -1,62 +1,44 @@
-<?php 
+<?php
 
 namespace Nakatsinho\MpesaLaravel\Commands;
 
-use Illuminate\Support\Facades\File;
 use Illuminate\Console\Command;
 
-
-class PublishSDK extends Command{
-
-
-    protected $name = 'mpesa-sdk:publish';
+class PublishSDK extends Command
+{
+    protected $signature = 'mpesa-sdk:publish';
 
     protected $description = 'Publishing files from the src folder';
 
-    public $composer;
-
-
-    public function __construct()
+    public function handle(): int
     {
-        parent::__construct();
-
-        $this->composer = app()['composer'];
-    }
-
-    public function handle(){
-
-        $publicDir = public_path();
         $appDir = app_path();
-        $resDir =  resource_path();
-        $confDir =  config_path();
-        $dataDir = database_path();
+        $resDir = resource_path();
+        $confDir = config_path();
 
-        $paymentController = file_get_contents(__DIR__.'/../Files/Controllers/PaymentController.stub');
-        $this->createFile($appDir. DIRECTORY_SEPARATOR."Http/Controllers/", 'PaymentController.php', $paymentController);
-        $this->info('Payment Controller was published right now.');
+        $paymentController = file_get_contents(__DIR__ . '/../Files/Controllers/PaymentController.stub');
+        $this->createFile($appDir . DIRECTORY_SEPARATOR . 'Http/Controllers/', 'PaymentController.php', $paymentController);
+        $this->info('Payment Controller was published.');
 
-        $configMpesa = file_get_contents(__DIR__.'/../Files/Config/Mpesa.stub');
-        $this->createFile($confDir. DIRECTORY_SEPARATOR, 'mpesa.php', $configMpesa);
-        $this->info('We have generated a fresh config service file.');
+        $configMpesa = file_get_contents(__DIR__ . '/../Files/Config/Mpesa.stub');
+        $this->createFile($confDir . DIRECTORY_SEPARATOR, 'mpesa.php', $configMpesa);
+        $this->info('Config file was generated.');
 
-        $bladeFile = file_get_contents(__DIR__.'/../Files/Views/index.stub');
-        $this->createFile($resDir. DIRECTORY_SEPARATOR, 'views/payments/index.blade.php', $bladeFile);
-        $this->info('We have generated a fresh blade file.');
+        $bladeFile = file_get_contents(__DIR__ . '/../Files/Views/index.stub');
+        $this->createFile($resDir . DIRECTORY_SEPARATOR, 'views/payments/index.blade.php', $bladeFile);
+        $this->info('Blade view was generated.');
 
-        $this->info('Generating fresh autoload files...');
-        $this->composer->dumpOptimized();
+        $this->info('Done! Enjoy your SDK.');
 
-        $this->info('Awesome Shit...! Enjoy your SDK.');
+        return self::SUCCESS;
     }
 
-    public static function createFile($path, $fileName, $contents)
+    public static function createFile(string $path, string $fileName, string $contents): void
     {
-        if(!file_exists($path)){
+        if (!file_exists($path)) {
             mkdir($path, 0755, true);
         }
 
-        $path = $path.$fileName;
-
-        file_put_contents($path, $contents);
+        file_put_contents($path . $fileName, $contents);
     }
 }

--- a/src/Facades/MpesaSDK.php
+++ b/src/Facades/MpesaSDK.php
@@ -1,15 +1,14 @@
-<?php 
+<?php
 
 namespace Nakatsinho\MpesaLaravel\Facades;
 
 use Illuminate\Support\Facades\Facade;
 use Nakatsinho\MpesaLaravel\Files\Config\ServiceVM as MPesaService;
 
-class MpesaSDK extends Facade{
-    
-    protected static function getFacadeAccessor()
+class MpesaSDK extends Facade
+{
+    protected static function getFacadeAccessor(): string
     {
-        // return 'mpesa-sdk';
         return MPesaService::class;
     }
 }

--- a/src/Files/Config/ServiceVM.php
+++ b/src/Files/Config/ServiceVM.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 namespace Nakatsinho\MpesaLaravel\Files\Config;
 
@@ -8,11 +8,11 @@ use Nakatsinho\MpesaPhp\interfaces\TransactionResponseInterface;
 
 class ServiceVM
 {
-    protected $transaction;
+    protected Transaction $transaction;
 
-    protected $configPath;
+    protected string $configPath;
 
-    public function __construct(string $configPath = null)
+    public function __construct(?string $configPath = null)
     {
         $this->configPath = $configPath ?? config_path('mpesa.php');
         $this->transaction = new Transaction(Config::loadFromFile($this->configPath));

--- a/src/Files/Controllers/PaymentController.stub
+++ b/src/Files/Controllers/PaymentController.stub
@@ -2,86 +2,27 @@
 
 namespace App\Http\Controllers;
 
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\View\View;
 use Nakatsinho\MpesaLaravel\Facades\MpesaSDK;
 
 class PaymentController extends Controller
 {
-    /**
-     * Display a listing of the resource.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function index()
+    public function index(): View
     {
         return view('payments.index');
     }
 
-    /**
-     * Show the form for creating a new resource.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function create()
+    public function store(Request $request): RedirectResponse
     {
-        //
-    }
+        $request->validate([
+            'amount' => ['required', 'numeric', 'min:1'],
+            'number' => ['required', 'string'],
+        ]);
 
-    /**
-     * Store a newly created resource in storage.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
-     */
-    public function store(Request $request)
-    {
-        $payment = MpesaSDK::c2b($request->amount,$request->number, "NAKATSINHO", bin2hex(random_bytes(6)));
-        
+        MpesaSDK::c2b($request->amount, $request->number, 'NAKATSINHO', bin2hex(random_bytes(6)));
+
         return redirect()->back();
-    }
-
-    /**
-     * Display the specified resource.
-     *
-     * @param  \App\Models\Payment  $payment
-     * @return \Illuminate\Http\Response
-     */
-    public function show( $payment)
-    {
-        //
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     *
-     * @param  \App\Models\Payment  $payment
-     * @return \Illuminate\Http\Response
-     */
-    public function edit( $payment)
-    {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \App\Models\Payment  $payment
-     * @return \Illuminate\Http\Response
-     */
-    public function update(Request $request,  $payment)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     *
-     * @param  \App\Models\Payment  $payment
-     * @return \Illuminate\Http\Response
-     */
-    public function destroy( $payment)
-    {
-        //
     }
 }

--- a/src/Providers/MPesaServiceProvider.php
+++ b/src/Providers/MPesaServiceProvider.php
@@ -7,29 +7,17 @@ use Nakatsinho\MpesaLaravel\Commands\PublishSDK;
 
 class MPesaServiceProvider extends ServiceProvider
 {
-    /**
-     * Register services.
-     *
-     * @return void
-     */
-    public function register()
-    {
-        $this->app->singleton('mpesa-sdk:publish', function ($app){
-            return new PublishSDK();
-        });
-
-        $this->commands([
-            'mpesa-sdk:publish',
-        ]);
-    }
-
-    /**
-     * Bootstrap services.
-     *
-     * @return void
-     */
-    public function boot()
+    public function register(): void
     {
         //
+    }
+
+    public function boot(): void
+    {
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                PublishSDK::class,
+            ]);
+        }
     }
 }


### PR DESCRIPTION
- Require php ^8.1|^8.2|^8.3|^8.4 (was >=7.0)
- Require illuminate/support ^10.0|^11.0|^12.0 (was >=5.8)
- Add illuminate/console to explicit requires
- Add require-dev with phpunit ^10-12 and orchestra/testbench ^8-10
- Add prefer-stable: true to composer.json

MPesaServiceProvider: move command registration to boot() using
class-based syntax with runningInConsole() guard (old string-based
singleton approach doesn't work in Laravel 10+)

PublishSDK: replace removed app()['composer']->dumpOptimized() call
(dropped in Laravel 9), switch $name to $signature, add PHP 8 return
types, return self::SUCCESS from handle()

ServiceVM: add typed properties and explicit nullable ?string param

MpesaSDK facade: add string return type to getFacadeAccessor()

phpunit.xml: update schema to PHPUnit 11, replace deprecated
processUncoveredFiles/coverage with <source> block, fix coverage
directory from ./app to ./src

PaymentController stub: remove unused methods, add PHP 8 return types,
add basic input validation

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SxjKEUMCcoLJdcgTk8KQV4